### PR TITLE
Added digest to hash-password

### DIFF
--- a/lib/hash-password.js
+++ b/lib/hash-password.js
@@ -4,7 +4,7 @@ var crypto = require('crypto')
 
 function hashPassword (password, salt, iterations) {
   return new Promise(function (resolve, reject) {
-    crypto.pbkdf2(password, salt, iterations, 20, function (err, derivedKey) {
+    crypto.pbkdf2(password, salt, iterations, 20, 'sha1', function (err, derivedKey) {
       if (err) {
         reject(err)
       } else {


### PR DESCRIPTION
On node.js version 6 the digest on crypto.pbkdf2 is required.
Default is 'sha1‘.