### PR TITLE
Backwards compatibility support for digest in hash-password

### DIFF
--- a/lib/hash-password.js
+++ b/lib/hash-password.js
@@ -11,7 +11,8 @@ function hashPassword (password, salt, iterations) {
         resolve(derivedKey.toString('hex'))
       }
     }
-    if (process.version >= 6) {
+    var version = Number(process.version.match(/^v(\d+\.\d+)/)[1])
+    if (version >= 6) {
       crypto.pbkdf2(password, salt, iterations, 20, 'sha1', cb);
     } else {
       crypto.pbkdf2(password, salt, iterations, 20, cb);

--- a/lib/hash-password.js
+++ b/lib/hash-password.js
@@ -4,12 +4,17 @@ var crypto = require('crypto')
 
 function hashPassword (password, salt, iterations) {
   return new Promise(function (resolve, reject) {
-    crypto.pbkdf2(password, salt, iterations, 20, 'sha1', function (err, derivedKey) {
+    var cb = function (err, derivedKey) {
       if (err) {
         reject(err)
       } else {
         resolve(derivedKey.toString('hex'))
       }
-    })
+    }
+    if (process.version >= 6) {
+      crypto.pbkdf2(password, salt, iterations, 20, 'sha1', cb);
+    } else {
+      crypto.pbkdf2(password, salt, iterations, 20, cb);
+    }
   })
 }


### PR DESCRIPTION
In Node.js 5 and below the call to crypto.pbkdf2 does not take a digest. This pull request includes code to check the version of Node and passes the digest only if the version >= 6.

Tested in Node 5, 6, and 8.