### PR TITLE
Allow db multi-use by only validating user type docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # pouchdb-users
 
-> PouchDB plugin to simulate CouchDB’s \_users database behavior
-> This forked version adds multi-db support
+> PouchDB plugin to simulate CouchDB’s \_users database behavior.
+
+This forked version allows _users behavior to be added to any db while still retaining the ability to add other doc types as well.  Only 'user' doc types are validated for _user db behavior.
 
 [![Build Status](https://travis-ci.org/hoodiehq/pouchdb-users.svg?branch=master)](https://travis-ci.org/hoodiehq/pouchdb-users)
 [![Coverage Status](https://coveralls.io/repos/hoodiehq/pouchdb-users/badge.svg?branch=master)](https://coveralls.io/r/hoodiehq/pouchdb-users?branch=master)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # pouchdb-users
 
 > PouchDB plugin to simulate CouchDB’s \_users database behavior
+> This forked version adds multi-db support
 
 [![Build Status](https://travis-ci.org/hoodiehq/pouchdb-users.svg?branch=master)](https://travis-ci.org/hoodiehq/pouchdb-users)
 [![Coverage Status](https://coveralls.io/repos/hoodiehq/pouchdb-users/badge.svg?branch=master)](https://coveralls.io/r/hoodiehq/pouchdb-users?branch=master)

--- a/lib/validate-doc-update.js
+++ b/lib/validate-doc-update.js
@@ -7,16 +7,8 @@ module.exports = function (newDoc, oldDoc, userCtx, secObj) {
     throw error
   }
 
-  if (newDoc._id.substr(0, 8) === '_design/') {
-    return
-  }
-
-  if (newDoc._id.substr(0, 7) === '_local/') {
-    return
-  }
-
   if ((oldDoc && oldDoc.type !== 'user') || newDoc.type !== 'user') {
-    throwError('doc.type must be user')
+    return
   }
 
   if (!newDoc.name) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pouchdb-users",
+  "name": "@inator/pouchdb-users",
   "version": "1.0.7",
   "description": "PouchDB plugin to simulate CouchDB’s _users database behavior",
   "main": "index.js",
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hoodiehq/pouchdb-users.git"
+    "url": "https://github.com/inator/pouchdb-users"
   },
   "keywords": [
     "couchdb",
@@ -27,9 +27,9 @@
   "author": "The Hoodie Community",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/hoodiehq/pouchdb-users/issues"
+    "url": "https://github.com/inator/pouchdb-users/issues"
   },
-  "homepage": "https://github.com/hoodiehq/pouchdb-users#readme",
+  "homepage": "https://github.com/inator/pouchdb-users#readme",
   "dependencies": {
     "lie": "^3.1.1",
     "pouchdb-bulkdocs-wrapper": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inator/pouchdb-users",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "PouchDB plugin to simulate CouchDB’s _users database behavior",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "pouchdb-users",
+  "version": "1.0.7",
   "description": "PouchDB plugin to simulate CouchDB’s _users database behavior",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change allows _users behavior to be added to any db while still retaining the ability to add other doc types as well. 